### PR TITLE
Allow function name to differ from callback name

### DIFF
--- a/angular-redactor.js
+++ b/angular-redactor.js
@@ -40,7 +40,7 @@
                     var redactorCallbacks = {};
                     if (additionalOptions.hasOwnProperty('callbacks') === true){
                         additionalOptions.callbacks.forEach(function(callback){
-                            redactorCallbacks[callback] = window[callback]
+                            redactorCallbacks[callback.type] = window[callback.functionName];
                         });
                     }
 


### PR DESCRIPTION
Allow callback name (eg. 'blurCallback') to be different from the function name attached to window
